### PR TITLE
feat: adding support for German

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Currently supported languages:
 - 🇯🇵 **Japanese (ja-JP)** - ✅ Complete (Thanks @HRTK92)
 - 🇸🇦 **Arabic (ar-SA)** - ✅ Complete (Thanks @mosaleh-dev)
 - 🇬🇷 **Greek (el-GR)** - ✅ Complete (Thanks @DomVournias)
+- 🇩🇪 **German (de-DE)** - ✅ Complete (Thanks @NiklasDah)
+  - 🇩🇪 **German (informal, "du") (de-DE-informal) (default)** - ✅ Complete (Thanks @NiklasDah)
+  - 🇩🇪 **German (formal, "Sie") (de-DE-formal)** - ✅ Complete (Thanks @NiklasDah)
 
 ## Installation
 

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -1,0 +1,51 @@
+import { ErrorCodesType } from "../types";
+
+export const DE_DE_INFORMAL = {
+  // User related errors
+  USER_NOT_FOUND: "Benutzer nicht gefunden",
+  FAILED_TO_CREATE_USER: "Benutzer konnte nicht erstellt werden",
+  FAILED_TO_UPDATE_USER: "Benutzer konnte nicht aktualisiert werden",
+  USER_ALREADY_EXISTS: "Benutzer bereits vorhanden",
+  USER_EMAIL_NOT_FOUND: "E-Mail-Adresse des Benutzers nicht gefunden",
+  USER_ALREADY_HAS_PASSWORD:
+    "Benutzer hat bereits ein Passwort. Bitte gib es ein, um das Konto zu löschen.",
+
+  // Session related errors
+  FAILED_TO_CREATE_SESSION: "Sitzung konnte nicht erstellt werden",
+  FAILED_TO_GET_SESSION: "Sitzung konnte nicht abgerufen werden",
+  SESSION_EXPIRED:
+    "Sitzung abgelaufen. Bitte melde dich erneut an, um diese Aktion auszuführen.",
+
+  // Authentication errors
+  INVALID_PASSWORD: "Ungültiges Passwort",
+  INVALID_EMAIL: "Ungültige E-Mail-Adresse",
+  INVALID_EMAIL_OR_PASSWORD: "Ungültige E-Mail-Adresse oder Passwort",
+  INVALID_TOKEN: "Ungültiger Token",
+  EMAIL_NOT_VERIFIED: "E-Mail-Adresse nicht verifiziert",
+  CREDENTIAL_ACCOUNT_NOT_FOUND: "Konto nicht gefunden",
+
+  // Password related errors
+  PASSWORD_TOO_SHORT: "Passwort zu kurz",
+  PASSWORD_TOO_LONG: "Passwort zu lang",
+
+  // Social auth errors
+  SOCIAL_ACCOUNT_ALREADY_LINKED: "Konto bereits verknüpft",
+  PROVIDER_NOT_FOUND: "Anbieter nicht gefunden",
+  ID_TOKEN_NOT_SUPPORTED: "id_token nicht unterstützt",
+  FAILED_TO_GET_USER_INFO:
+    "Informationen des Benutzers konnten nicht abgerufen werden",
+
+  // Account management errors
+  EMAIL_CAN_NOT_BE_UPDATED: "E-Mail-Adresse konnte nicht aktualisiert werden",
+  FAILED_TO_UNLINK_LAST_ACCOUNT: "Du kannst das letzte Konto nicht trennen",
+  ACCOUNT_NOT_FOUND: "Konto nicht gefunden",
+} satisfies ErrorCodesType;
+
+export const DE_DE_FORMAL = {
+  ...DE_DE_INFORMAL,
+  USER_ALREADY_HAS_PASSWORD:
+    "Der Benutzer hat bereits ein Passwort. Bitte geben Sie es ein, um das Konto zu löschen.",
+  SESSION_EXPIRED:
+    "Sitzung abgelaufen. Bitte melden Sie sich erneut an, um diese Aktion auszuführen.",
+  FAILED_TO_UNLINK_LAST_ACCOUNT: "Sie können das letzte Konto nicht trennen",
+} satisfies ErrorCodesType;

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -6,15 +6,19 @@ import { ID_ID } from "./id";
 import { AR_SA } from "./ar";
 import { JA_JP } from "./ja";
 import { EL_GR } from "./el";
+import { DE_DE_INFORMAL, DE_DE_FORMAL } from "./de";
 
 export const defaultTranslations = {
-	"pt-BR": PT_BR,
-	"pt-PT": PT_PT,
-	"es-ES": ES_ES,
-	"fr-FR": FR_FR,
-	"pl-PL": PL_PL,
-	"id-ID": ID_ID,
-	"ar-SA": AR_SA,
-	"ja-JP": JA_JP,
-	"el-GR": EL_GR,
+  "pt-BR": PT_BR,
+  "pt-PT": PT_PT,
+  "es-ES": ES_ES,
+  "fr-FR": FR_FR,
+  "pl-PL": PL_PL,
+  "id-ID": ID_ID,
+  "ar-SA": AR_SA,
+  "ja-JP": JA_JP,
+  "el-GR": EL_GR,
+  "de-DE": DE_DE_INFORMAL,
+  "de-DE-formal": DE_DE_FORMAL,
+  "de-DE-informal": DE_DE_INFORMAL,
 };


### PR DESCRIPTION
I added support for German :).

Please note that German has a formal way of communicating with people and an informal way, so I added it twice (`de-DE-informal` and `de-DE-formal`). I mapped the informal to `de-DE` as more and more companies default to informal communication with customers.