### PR TITLE
fix: preserve original error codes in translations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,6 +133,7 @@ export const localization = <
 						if (translatedMessage) {
 							return ctx.error(statusCode || "UNPROCESSABLE_ENTITY", {
 								message: translatedMessage,
+								code: body.code,
 							});
 						}
 					}),


### PR DESCRIPTION
This PR closes #29

Preserves the original error code when returning translated error messages.