### PR TITLE
feat(i18n): add  Bengali (bn-BD) laocale 

### DIFF
--- a/src/translations/bn.ts
+++ b/src/translations/bn.ts
@@ -1,0 +1,48 @@
+import { createTranslationObject } from "../utils/create-translation-object";
+
+export const BN_BD = createTranslationObject("bn-BD", {
+    // User related errors
+    USER_NOT_FOUND: "ব্যবহারকারী পাওয়া যায়নি",
+    FAILED_TO_CREATE_USER: "ব্যবহারকারী তৈরি করতে ব্যর্থ",
+    FAILED_TO_UPDATE_USER: "ব্যবহারকারী আপডেট করতে ব্যর্থ",
+    USER_ALREADY_EXISTS: "ব্যবহারকারী ইতিমধ্যে বিদ্যমান",
+    USER_EMAIL_NOT_FOUND: "ব্যবহারকারীর ইমেল পাওয়া যায়নি",
+    USER_ALREADY_HAS_PASSWORD:
+        "ব্যবহারকারীর ইতিমধ্যে একটি পাসওয়ার্ড আছে। অ্যাকাউন্ট মুছে ফেলার জন্য এটি প্রদান করুন।",
+    USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL:
+        "ব্যবহারকারী ইতিমধ্যে বিদ্যমান। অন্য একটি ইমেল ব্যবহার করুন।",
+
+    // Session related errors
+    FAILED_TO_CREATE_SESSION: "সেশন তৈরি করতে ব্যর্থ",
+    FAILED_TO_GET_SESSION: "সেশন পেতে ব্যর্থ",
+    SESSION_EXPIRED:
+        "সেশনের মেয়াদ শেষ হয়ে গেছে। এই কার্যটি সম্পাদন করতে আবার লগইন করুন।",
+
+    // Authentication errors
+    INVALID_PASSWORD: "ভুল পাসওয়ার্ড",
+    INVALID_EMAIL: "ভুল ইমেল",
+    INVALID_EMAIL_OR_PASSWORD: "ভুল ইমেল বা পাসওয়ার্ড",
+    INVALID_TOKEN: "ভুল টোকেন",
+    EMAIL_NOT_VERIFIED: "ইমেল যাচাই করা হয়নি",
+    CREDENTIAL_ACCOUNT_NOT_FOUND: "শংসাপত্র অ্যাকাউন্ট পাওয়া যায়নি",
+
+    // Password related errors
+    PASSWORD_TOO_SHORT: "পাসওয়ার্ড অত্যন্ত ছোট",
+    PASSWORD_TOO_LONG: "পাসওয়ার্ড অত্যন্ত বড়",
+
+    // Social auth errors
+    SOCIAL_ACCOUNT_ALREADY_LINKED: "সোশ্যাল অ্যাকাউন্ট ইতিমধ্যে সংযুক্ত",
+    PROVIDER_NOT_FOUND: "প্রদানকারী পাওয়া যায়নি",
+    ID_TOKEN_NOT_SUPPORTED: "id_token সমর্থিত নয়",
+    FAILED_TO_GET_USER_INFO: "ব্যবহারকারীর তথ্য পেতে ব্যর্থ",
+
+    // Account management errors
+    EMAIL_CAN_NOT_BE_UPDATED: "ইমেল আপডেট করা যাবে না",
+    FAILED_TO_UNLINK_LAST_ACCOUNT:
+        "আপনি আপনার শেষ অ্যাকাউন্ট সংযোগ বিচ্ছিন্ন করতে পারবেন না",
+    ACCOUNT_NOT_FOUND: "অ্যাকাউন্ট পাওয়া যায়নি",
+});
+
+export const LOCALES = {
+    "bn-BD": BN_BD,
+} as const;

--- a/src/translations/plugins/admin/bn.ts
+++ b/src/translations/plugins/admin/bn.ts
@@ -1,0 +1,29 @@
+import type { AdminErrorCodesType } from "../../../types";
+
+export const BN_BD = {
+    // Admin related errors
+    YOU_CANNOT_BAN_YOURSELF: "আপনি নিজেকে নিষিদ্ধ করতে পারবেন না",
+    YOU_ARE_NOT_ALLOWED_TO_CHANGE_USERS_ROLE:
+        "আপনার ব্যবহারকারীদের ভূমিকা পরিবর্তন করার অনুমতি নেই",
+    YOU_ARE_NOT_ALLOWED_TO_CREATE_USERS: "আপনার ব্যবহারকারী তৈরি করার অনুমতি নেই",
+    YOU_ARE_NOT_ALLOWED_TO_LIST_USERS: "আপনার ব্যবহারকারী তালিকা দেখার অনুমতি নেই",
+    YOU_ARE_NOT_ALLOWED_TO_LIST_USERS_SESSIONS:
+        "আপনার ব্যবহারকারীদের সেশন তালিকা দেখার অনুমতি নেই",
+    YOU_ARE_NOT_ALLOWED_TO_BAN_USERS: "আপনার ব্যবহারকারী নিষিদ্ধ করার অনুমতি নেই",
+    YOU_ARE_NOT_ALLOWED_TO_IMPERSONATE_USERS:
+        "আপনার ব্যবহারকারীদের ছদ্মবেশ ধারণ করার অনুমতি নেই",
+    YOU_ARE_NOT_ALLOWED_TO_REVOKE_USERS_SESSIONS:
+        "আপনার ব্যবহারকারীদের সেশন বাতিল করার অনুমতি নেই",
+    YOU_ARE_NOT_ALLOWED_TO_DELETE_USERS: "আপনার ব্যবহারকারী মুছে ফেলার অনুমতি নেই",
+    YOU_ARE_NOT_ALLOWED_TO_SET_USERS_PASSWORD:
+        "আপনার ব্যবহারকারীদের পাসওয়ার্ড সেট করার অনুমতি নেই",
+    BANNED_USER: "আপনি এই অ্যাপ্লিকেশন থেকে নিষিদ্ধ করা হয়েছে",
+    YOU_ARE_NOT_ALLOWED_TO_GET_USER: "আপনার ব্যবহারকারী পাওয়ার অনুমতি নেই",
+    NO_DATA_TO_UPDATE: "আপডেট করার জন্য কোনো ডেটা নেই",
+    YOU_ARE_NOT_ALLOWED_TO_UPDATE_USERS: "আপনার ব্যবহারকারী আপডেট করার অনুমতি নেই",
+    YOU_CANNOT_REMOVE_YOURSELF: "আপনি নিজেকে সরাতে পারবেন না",
+} satisfies AdminErrorCodesType;
+
+export const LOCALES = {
+    "bn-BD": BN_BD,
+} as const;

--- a/src/translations/plugins/anonymous/bn.ts
+++ b/src/translations/plugins/anonymous/bn.ts
@@ -1,0 +1,12 @@
+import type { AnonymousErrorCodesType } from "../../../types";
+
+export const BN_BD = {
+    // Anonymous related errors
+    COULD_NOT_CREATE_SESSION: "সেশন তৈরি করা যায়নি",
+    ANONYMOUS_USERS_CANNOT_SIGN_IN_AGAIN_ANONYMOUSLY:
+        "বেনামী ব্যবহারকারীরা আবার বেনামী হিসাবে সাইন ইন করতে পারবেন না",
+} satisfies AnonymousErrorCodesType;
+
+export const LOCALES = {
+    "bn-BD": BN_BD,
+} as const;

--- a/src/translations/plugins/api-key/bn.ts
+++ b/src/translations/plugins/api-key/bn.ts
@@ -1,0 +1,38 @@
+import type { ApiKeyErrorCodesType } from "../../../types";
+
+export const BN_BD = {
+    // Api key related errors
+    INVALID_METADATA_TYPE: "metadata একটি অবজেক্ট বা undefined হতে হবে",
+    REFILL_AMOUNT_AND_INTERVAL_REQUIRED:
+        "রিফিল ইন্টারভাল প্রদান করা হলে রিফিল পরিমাণ প্রয়োজন",
+    REFILL_INTERVAL_AND_AMOUNT_REQUIRED:
+        "রিফিল পরিমাণ প্রদান করা হলে রিফিল ইন্টারভাল প্রয়োজন",
+    USER_BANNED: "ব্যবহারকারী নিষিদ্ধ",
+    UNAUTHORIZED_SESSION: "অননুমোদিত বা অবৈধ সেশন",
+    KEY_NOT_FOUND: "API কী পাওয়া যায়নি",
+    KEY_DISABLED: "API কী নিষ্ক্রিয়",
+    KEY_EXPIRED: "API কীর মেয়াদ শেষ হয়ে গেছে",
+    USAGE_EXCEEDED: "API কী ব্যবহারের সীমা অতিক্রম করেছে",
+    KEY_NOT_RECOVERABLE: "API কী পুনরুদ্ধারযোগ্য নয়",
+    EXPIRES_IN_IS_TOO_SMALL: "মেয়াদ শেষের সময় পূর্বনির্ধারিত ন্যূনতম মানের চেয়ে কম।",
+    EXPIRES_IN_IS_TOO_LARGE: "মেয়াদ শেষের সময় পূর্বনির্ধারিত সর্বোচ্চ মানের চেয়ে বড়।",
+    INVALID_REMAINING: "অবশিষ্ট মান অত্যন্ত বড় বা অত্যন্ত ছোট।",
+    INVALID_PREFIX_LENGTH: "উপসর্গের দৈর্ঘ্য অত্যন্ত বড় বা অত্যন্ত ছোট।",
+    INVALID_NAME_LENGTH: "নামের দৈর্ঘ্য অত্যন্ত বড় বা অত্যন্ত ছোট।",
+    METADATA_DISABLED: "Metadata নিষ্ক্রিয়।",
+    RATE_LIMIT_EXCEEDED: "রেট সীমা অতিক্রম করেছে।",
+    NO_VALUES_TO_UPDATE: "আপডেট করার জন্য কোনো মান নেই।",
+    KEY_DISABLED_EXPIRATION: "কাস্টম কী মেয়াদ শেষ মান নিষ্ক্রিয়।",
+    INVALID_API_KEY: "ভুল API কী।",
+    INVALID_USER_ID_FROM_API_KEY: "API কী থেকে ব্যবহারকারী ID অবৈধ।",
+    INVALID_API_KEY_GETTER_RETURN_TYPE:
+        "API কী getter একটি অবৈধ টাইপ রিটার্ন করেছে। প্রত্যাশিত: string।",
+    SERVER_ONLY_PROPERTY:
+        "আপনি যে প্রপার্টি সেট করার চেষ্টা করছেন তা শুধুমাত্র সার্ভার অথ ইনস্ট্যান্স থেকে সেট করা যেতে পারে।",
+    FAILED_TO_UPDATE_API_KEY: "API কী আপডেট করতে ব্যর্থ",
+    NAME_REQUIRED: "API কী নাম প্রয়োজন।",
+} satisfies ApiKeyErrorCodesType;
+
+export const LOCALES = {
+    "bn-BD": BN_BD,
+} as const;

--- a/src/translations/plugins/device-authorization/bn.ts
+++ b/src/translations/plugins/device-authorization/bn.ts
@@ -1,0 +1,19 @@
+import type { DeviceAuthorizationErrorCodesType } from "../../../types";
+
+export const BN_BD = {
+    // Device authorization related errors
+    INVALID_DEVICE_CODE: "ভুল ডিভাইস কোড",
+    EXPIRED_DEVICE_CODE: "ডিভাইস কোডের মেয়াদ শেষ হয়ে গেছে",
+    EXPIRED_USER_CODE: "ব্যবহারকারী কোডের মেয়াদ শেষ হয়ে গেছে",
+    AUTHORIZATION_PENDING: "অনুমোদন অপেক্ষমাণ",
+    ACCESS_DENIED: "প্রবেশাধিকার প্রত্যাখ্যাত",
+    INVALID_USER_CODE: "ভুল ব্যবহারকারী কোড",
+    DEVICE_CODE_ALREADY_PROCESSED: "ডিভাইস কোড ইতিমধ্যে প্রক্রিয়া করা হয়েছে",
+    POLLING_TOO_FREQUENTLY: "অত্যধিক ঘন ঘন পোলিং",
+    INVALID_DEVICE_CODE_STATUS: "ভুল ডিভাইস কোড স্ট্যাটাস",
+    AUTHENTICATION_REQUIRED: "প্রমাণীকরণ প্রয়োজন",
+} satisfies DeviceAuthorizationErrorCodesType;
+
+export const LOCALES = {
+    "bn-BD": BN_BD,
+} as const;

--- a/src/translations/plugins/email-otp/bn.ts
+++ b/src/translations/plugins/email-otp/bn.ts
@@ -1,0 +1,10 @@
+import type { EmailOTPErrorCodesType } from "../../../types";
+
+export const BN_BD = {
+    // Email OTP related errors
+    TOO_MANY_ATTEMPTS: "অত্যধিক প্রচেষ্টা",
+} satisfies EmailOTPErrorCodesType;
+
+export const LOCALES = {
+    "bn-BD": BN_BD,
+} as const;

--- a/src/translations/plugins/generic-oauth/bn.ts
+++ b/src/translations/plugins/generic-oauth/bn.ts
@@ -1,0 +1,10 @@
+import type { GenericOAuthErrorCodesType } from "../../../types";
+
+export const BN_BD = {
+    // Generic OAuth related errors
+    INVALID_OAUTH_CONFIGURATION: "ভুল OAuth কনফিগারেশন",
+} satisfies GenericOAuthErrorCodesType;
+
+export const LOCALES = {
+    "bn-BD": BN_BD,
+} as const;

--- a/src/translations/plugins/have-i-been-pwned/bn.ts
+++ b/src/translations/plugins/have-i-been-pwned/bn.ts
@@ -1,0 +1,11 @@
+import type { HaveIBeenPwnedErrorCodesType } from "../../../types";
+
+export const BN_BD = {
+    // Have I Been Pwned related errors
+    PASSWORD_COMPROMISED:
+        "আপনার প্রদত্ত পাসওয়ার্ডটি আপসকৃত হয়েছে। অনুগ্রহ করে ভিন্ন একটি পাসওয়ার্ড নির্বাচন করুন।",
+} satisfies HaveIBeenPwnedErrorCodesType;
+
+export const LOCALES = {
+    "bn-BD": BN_BD,
+} as const;

--- a/src/translations/plugins/multi-session/bn.ts
+++ b/src/translations/plugins/multi-session/bn.ts
@@ -1,0 +1,10 @@
+import type { MultiSessionErrorCodesType } from "../../../types";
+
+export const BN_BD = {
+    // Multi session related errors
+    INVALID_SESSION_TOKEN: "ভুল সেশন টোকেন",
+} satisfies MultiSessionErrorCodesType;
+
+export const LOCALES = {
+    "bn-BD": BN_BD,
+} as const;

--- a/src/translations/plugins/organization/bn.ts
+++ b/src/translations/plugins/organization/bn.ts
@@ -1,0 +1,70 @@
+import type { OrganizationErrorCodesType } from "../../../types";
+
+export const BN_BD = {
+    // Organization related errors
+    YOU_ARE_NOT_ALLOWED_TO_CREATE_A_NEW_ORGANIZATION:
+        "আপনার নতুন সংস্থা তৈরি করার অনুমতি নেই",
+    YOU_HAVE_REACHED_THE_MAXIMUM_NUMBER_OF_ORGANIZATIONS:
+        "আপনি সর্বাধিক সংখ্যক সংস্থায় পৌঁছেছেন",
+    ORGANIZATION_ALREADY_EXISTS: "সংস্থা ইতিমধ্যে বিদ্যমান",
+    ORGANIZATION_NOT_FOUND: "সংস্থা পাওয়া যায়নি",
+    USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION: "ব্যবহারকারী সংস্থার সদস্য নন",
+    YOU_ARE_NOT_ALLOWED_TO_UPDATE_THIS_ORGANIZATION:
+        "আপনার এই সংস্থা আপডেট করার অনুমতি নেই",
+    YOU_ARE_NOT_ALLOWED_TO_DELETE_THIS_ORGANIZATION:
+        "আপনার এই সংস্থা মুছে ফেলার অনুমতি নেই",
+    NO_ACTIVE_ORGANIZATION: "কোনো সক্রিয় সংস্থা নেই",
+    USER_IS_ALREADY_A_MEMBER_OF_THIS_ORGANIZATION:
+        "ব্যবহারকারী ইতিমধ্যে এই সংস্থার সদস্য",
+    MEMBER_NOT_FOUND: "সদস্য পাওয়া যায়নি",
+    ROLE_NOT_FOUND: "ভূমিকা পাওয়া যায়নি",
+    YOU_ARE_NOT_ALLOWED_TO_CREATE_A_NEW_TEAM: "আপনার নতুন দল তৈরি করার অনুমতি নেই",
+    TEAM_ALREADY_EXISTS: "দল ইতিমধ্যে বিদ্যমান",
+    TEAM_NOT_FOUND: "দল পাওয়া যায়নি",
+    YOU_CANNOT_LEAVE_THE_ORGANIZATION_AS_THE_ONLY_OWNER:
+        "আপনি একমাত্র মালিক হিসাবে সংস্থা ত্যাগ করতে পারবেন না",
+    YOU_CANNOT_LEAVE_THE_ORGANIZATION_WITHOUT_AN_OWNER:
+        "আপনি মালিক ছাড়া সংস্থা ত্যাগ করতে পারবেন না",
+    YOU_ARE_NOT_ALLOWED_TO_DELETE_THIS_MEMBER: "আপনার এই সদস্য মুছে ফেলার অনুমতি নেই",
+    YOU_ARE_NOT_ALLOWED_TO_INVITE_USERS_TO_THIS_ORGANIZATION:
+        "আপনার এই সংস্থায় ব্যবহারকারীদের আমন্ত্রণ জানানোর অনুমতি নেই",
+    USER_IS_ALREADY_INVITED_TO_THIS_ORGANIZATION:
+        "ব্যবহারকারী ইতিমধ্যে এই সংস্থায় আমন্ত্রিত",
+    INVITATION_NOT_FOUND: "আমন্ত্রণ পাওয়া যায়নি",
+    YOU_ARE_NOT_THE_RECIPIENT_OF_THE_INVITATION: "আপনি আমন্ত্রণের প্রাপক নন",
+    EMAIL_VERIFICATION_REQUIRED_BEFORE_ACCEPTING_OR_REJECTING_INVITATION:
+        "আমন্ত্রণ গ্রহণ বা প্রত্যাখ্যান করার আগে ইমেল যাচাইকরণ প্রয়োজন",
+    YOU_ARE_NOT_ALLOWED_TO_CANCEL_THIS_INVITATION:
+        "আপনার এই আমন্ত্রণ বাতিল করার অনুমতি নেই",
+    INVITER_IS_NO_LONGER_A_MEMBER_OF_THE_ORGANIZATION:
+        "আমন্ত্রণকারী আর সংস্থার সদস্য নন",
+    YOU_ARE_NOT_ALLOWED_TO_INVITE_USER_WITH_THIS_ROLE:
+        "আপনার এই ভূমিকায় ব্যবহারকারীকে আমন্ত্রণ জানানোর অনুমতি নেই",
+    FAILED_TO_RETRIEVE_INVITATION: "আমন্ত্রণ পুনরুদ্ধার করতে ব্যর্থ",
+    YOU_HAVE_REACHED_THE_MAXIMUM_NUMBER_OF_TEAMS: "আপনি সর্বাধিক সংখ্যক দলে পৌঁছেছেন",
+    UNABLE_TO_REMOVE_LAST_TEAM: "শেষ দল সরাতে অক্ষম",
+    YOU_ARE_NOT_ALLOWED_TO_UPDATE_THIS_MEMBER: "আপনার এই সদস্য আপডেট করার অনুমতি নেই",
+    ORGANIZATION_MEMBERSHIP_LIMIT_REACHED: "সংস্থার সদস্যপদ সীমা পৌঁছেছে",
+    YOU_ARE_NOT_ALLOWED_TO_CREATE_TEAMS_IN_THIS_ORGANIZATION:
+        "আপনার এই সংস্থায় দল তৈরি করার অনুমতি নেই",
+    YOU_ARE_NOT_ALLOWED_TO_DELETE_TEAMS_IN_THIS_ORGANIZATION:
+        "আপনার এই সংস্থায় দল মুছে ফেলার অনুমতি নেই",
+    YOU_ARE_NOT_ALLOWED_TO_UPDATE_THIS_TEAM: "আপনার এই দল আপডেট করার অনুমতি নেই",
+    YOU_ARE_NOT_ALLOWED_TO_DELETE_THIS_TEAM: "আপনার এই দল মুছে ফেলার অনুমতি নেই",
+    INVITATION_LIMIT_REACHED: "আমন্ত্রণ সীমা পৌঁছেছে",
+    TEAM_MEMBER_LIMIT_REACHED: "দলের সদস্য সীমা পৌঁছেছে",
+    USER_IS_NOT_A_MEMBER_OF_THE_TEAM: "ব্যবহারকারী দলের সদস্য নন",
+    YOU_CAN_NOT_ACCESS_THE_MEMBERS_OF_THIS_TEAM:
+        "আপনি এই দলের সদস্যদের অ্যাক্সেস করতে পারবেন না",
+    YOU_DO_NOT_HAVE_AN_ACTIVE_TEAM: "আপনার কোনো সক্রিয় দল নেই",
+    YOU_ARE_NOT_ALLOWED_TO_CREATE_A_NEW_TEAM_MEMBER:
+        "আপনার নতুন দলের সদস্য তৈরি করার অনুমতি নেই",
+    YOU_ARE_NOT_ALLOWED_TO_REMOVE_A_TEAM_MEMBER: "আপনার দলের সদস্য সরানোর অনুমতি নেই",
+    YOU_ARE_NOT_ALLOWED_TO_ACCESS_THIS_ORGANIZATION:
+        "আপনার মালিক হিসাবে এই সংস্থায় অ্যাক্সেস করার অনুমতি নেই",
+    YOU_ARE_NOT_A_MEMBER_OF_THIS_ORGANIZATION: "আপনি এই সংস্থার সদস্য নন",
+} satisfies OrganizationErrorCodesType;
+
+export const LOCALES = {
+    "bn-BD": BN_BD,
+} as const;

--- a/src/translations/plugins/passkey/bn.ts
+++ b/src/translations/plugins/passkey/bn.ts
@@ -1,0 +1,17 @@
+import type { PasskeyErrorCodesType } from "../../../types";
+
+export const BN_BD = {
+    // Passkey related errors
+    CHALLENGE_NOT_FOUND: "চ্যালেঞ্জ পাওয়া যায়নি",
+    YOU_ARE_NOT_ALLOWED_TO_REGISTER_THIS_PASSKEY:
+        "আপনার এই পাসকি নিবন্ধন করার অনুমতি নেই",
+    FAILED_TO_VERIFY_REGISTRATION: "নিবন্ধন যাচাই করতে ব্যর্থ",
+    PASSKEY_NOT_FOUND: "পাসকি পাওয়া যায়নি",
+    AUTHENTICATION_FAILED: "প্রমাণীকরণ ব্যর্থ",
+    UNABLE_TO_CREATE_SESSION: "সেশন তৈরি করতে অক্ষম",
+    FAILED_TO_UPDATE_PASSKEY: "পাসকি আপডেট করতে ব্যর্থ",
+} satisfies PasskeyErrorCodesType;
+
+export const LOCALES = {
+    "bn-BD": BN_BD,
+} as const;

--- a/src/translations/plugins/phone-number/bn.ts
+++ b/src/translations/plugins/phone-number/bn.ts
@@ -1,0 +1,17 @@
+import type { PhoneNumberErrorCodesType } from "../../../types";
+
+export const BN_BD = {
+    // Phone number related errors
+    INVALID_PHONE_NUMBER: "ভুল ফোন নম্বর",
+    PHONE_NUMBER_EXIST: "ফোন নম্বর ইতিমধ্যে বিদ্যমান",
+    INVALID_PHONE_NUMBER_OR_PASSWORD: "ভুল ফোন নম্বর বা পাসওয়ার্ড",
+    UNEXPECTED_ERROR: "অপ্রত্যাশিত ত্রুটি",
+    OTP_NOT_FOUND: "OTP পাওয়া যায়নি",
+    OTP_EXPIRED: "OTP এর মেয়াদ শেষ হয়ে গেছে",
+    INVALID_OTP: "ভুল OTP",
+    PHONE_NUMBER_NOT_VERIFIED: "ফোন নম্বর যাচাই করা হয়নি",
+} satisfies PhoneNumberErrorCodesType;
+
+export const LOCALES = {
+    "bn-BD": BN_BD,
+} as const;

--- a/src/translations/plugins/two-factor/bn.ts
+++ b/src/translations/plugins/two-factor/bn.ts
@@ -1,0 +1,19 @@
+import type { TwoFactorErrorCodesType } from "../../../types";
+
+export const BN_BD = {
+    // Two Factor related errors
+    OTP_NOT_ENABLED: "OTP সক্রিয় নয়",
+    OTP_HAS_EXPIRED: "OTP এর মেয়াদ শেষ হয়ে গেছে",
+    TOTP_NOT_ENABLED: "TOTP সক্রিয় নয়",
+    TWO_FACTOR_NOT_ENABLED: "দুই-ফ্যাক্টর সক্রিয় নয়",
+    BACKUP_CODES_NOT_ENABLED: "ব্যাকআপ কোড সক্রিয় নয়",
+    INVALID_BACKUP_CODE: "ভুল ব্যাকআপ কোড",
+    INVALID_CODE: "ভুল কোড",
+    TOO_MANY_ATTEMPTS_REQUEST_NEW_CODE:
+        "অত্যধিক প্রচেষ্টা। অনুগ্রহ করে একটি নতুন কোড অনুরোধ করুন।",
+    INVALID_TWO_FACTOR_COOKIE: "ভুল দুই-ফ্যাক্টর কুকি",
+} satisfies TwoFactorErrorCodesType;
+
+export const LOCALES = {
+    "bn-BD": BN_BD,
+} as const;

--- a/src/translations/plugins/username/bn.ts
+++ b/src/translations/plugins/username/bn.ts
@@ -1,0 +1,16 @@
+import type { UsernameErrorCodesType } from "../../../types";
+
+export const BN_BD = {
+    // Username related errors
+    INVALID_USERNAME_OR_PASSWORD: "ভুল ব্যবহারকারীর নাম বা পাসওয়ার্ড",
+    USERNAME_IS_ALREADY_TAKEN:
+        "ব্যবহারকারীর নাম ইতিমধ্যে ব্যবহৃত হচ্ছে। অনুগ্রহ করে অন্যটি চেষ্টা করুন।",
+    USERNAME_TOO_SHORT: "ব্যবহারকারীর নাম অত্যন্ত ছোট",
+    USERNAME_TOO_LONG: "ব্যবহারকারীর নাম অত্যন্ত বড়",
+    INVALID_USERNAME: "ভুল ব্যবহারকারীর নাম",
+    INVALID_DISPLAY_USERNAME: "ভুল প্রদর্শন নাম",
+} satisfies UsernameErrorCodesType;
+
+export const LOCALES = {
+    "bn-BD": BN_BD,
+} as const;


### PR DESCRIPTION
Adds   Bengali (bn-BD) translations.

- Generated via npm run generate:locale (entered az_AZ)
- Translated core error messages
- Translated official plugin error messages (admin, anonymous, api-key, device-authorization, email-otp, generic-oauth, have-i-been-pwned, multi-session, organization, passkey, phone-number, two-factor, username)
- Did not edit src/translations/index.ts (auto-generated by build/tests)

Checklist:

 

- [X] npm run generate:translations and npm run build succeed
- [X]  npm test passes
- [X] Formatted/linted