### PR TITLE
feat: add Ukrainian (uk-UA) translations

### DIFF
--- a/src/translations/plugins/admin/uk.ts
+++ b/src/translations/plugins/admin/uk.ts
@@ -1,0 +1,35 @@
+import type { AdminErrorCodesType } from "../../../types";
+
+export const UK_UA = {
+	// Admin related errors
+	YOU_CANNOT_BAN_YOURSELF: "Ви не можете заблокувати себе",
+	YOU_ARE_NOT_ALLOWED_TO_CHANGE_USERS_ROLE:
+		"Ви не маєте дозволу змінювати ролі користувачів",
+	YOU_ARE_NOT_ALLOWED_TO_CREATE_USERS:
+		"Ви не маєте дозволу створювати користувачів",
+	YOU_ARE_NOT_ALLOWED_TO_LIST_USERS:
+		"Ви не маєте дозволу переглядати список користувачів",
+	YOU_ARE_NOT_ALLOWED_TO_LIST_USERS_SESSIONS:
+		"Ви не маєте дозволу переглядати сесії користувачів",
+	YOU_ARE_NOT_ALLOWED_TO_BAN_USERS:
+		"Ви не маєте дозволу блокувати користувачів",
+	YOU_ARE_NOT_ALLOWED_TO_IMPERSONATE_USERS:
+		"Ви не маєте дозволу видавати себе за інших користувачів",
+	YOU_ARE_NOT_ALLOWED_TO_REVOKE_USERS_SESSIONS:
+		"Ви не маєте дозволу відкликати сесії користувачів",
+	YOU_ARE_NOT_ALLOWED_TO_DELETE_USERS:
+		"Ви не маєте дозволу видаляти користувачів",
+	YOU_ARE_NOT_ALLOWED_TO_SET_USERS_PASSWORD:
+		"Ви не маєте дозволу встановлювати паролі користувачів",
+	BANNED_USER: "Вас заблоковано у цьому застосунку",
+	YOU_ARE_NOT_ALLOWED_TO_GET_USER:
+		"Ви не маєте дозволу отримувати дані користувача",
+	NO_DATA_TO_UPDATE: "Немає даних для оновлення",
+	YOU_ARE_NOT_ALLOWED_TO_UPDATE_USERS:
+		"Ви не маєте дозволу оновлювати користувачів",
+	YOU_CANNOT_REMOVE_YOURSELF: "Ви не можете видалити себе",
+} satisfies AdminErrorCodesType;
+
+export const LOCALES = {
+	"uk-UA": UK_UA,
+} as const;

--- a/src/translations/plugins/anonymous/uk.ts
+++ b/src/translations/plugins/anonymous/uk.ts
@@ -1,0 +1,12 @@
+import type { AnonymousErrorCodesType } from "../../../types";
+
+export const UK_UA = {
+	// Anonymous related errors
+	COULD_NOT_CREATE_SESSION: "Не вдалося створити сесію",
+	ANONYMOUS_USERS_CANNOT_SIGN_IN_AGAIN_ANONYMOUSLY:
+		"Анонімні користувачі не можуть увійти знову анонімно",
+} satisfies AnonymousErrorCodesType;
+
+export const LOCALES = {
+	"uk-UA": UK_UA,
+} as const;

--- a/src/translations/plugins/api-key/uk.ts
+++ b/src/translations/plugins/api-key/uk.ts
@@ -1,0 +1,43 @@
+import type { ApiKeyErrorCodesType } from "../../../types";
+
+export const UK_UA = {
+	// Api key related errors
+	INVALID_METADATA_TYPE: "metadata має бути об'єктом або undefined",
+	REFILL_AMOUNT_AND_INTERVAL_REQUIRED:
+		"кількість поповнення потрібна, коли вказано інтервал поповнення",
+	REFILL_INTERVAL_AND_AMOUNT_REQUIRED:
+		"інтервал поповнення потрібен, коли вказано кількість поповнення",
+	USER_BANNED: "користувача заблоковано",
+	UNAUTHORIZED_SESSION: "неавторизована або недійсна сесія",
+	KEY_NOT_FOUND: "API ключ не знайдено",
+	KEY_DISABLED: "API ключ вимкнено",
+	KEY_EXPIRED: "API ключ прострочено",
+	USAGE_EXCEEDED: "API ключ перевищив ліміт використання",
+	KEY_NOT_RECOVERABLE: "API ключ не може бути відновлено",
+	EXPIRES_IN_IS_TOO_SMALL:
+		"час закінчення менший за попередньо визначене мінімальне значення.",
+	EXPIRES_IN_IS_TOO_LARGE:
+		"час закінчення більший за попередньо визначене максимальне значення.",
+	INVALID_REMAINING:
+		"залишкове значення занадто велике або занадто мале.",
+	INVALID_PREFIX_LENGTH:
+		"розмір префікса занадто великий або занадто малий.",
+	INVALID_NAME_LENGTH: "розмір імені занадто великий або занадто малий.",
+	METADATA_DISABLED: "метадані вимкнено.",
+	RATE_LIMIT_EXCEEDED: "ліміт запитів перевищено.",
+	NO_VALUES_TO_UPDATE: "немає значень для оновлення.",
+	KEY_DISABLED_EXPIRATION:
+		"користувацькі значення закінчення ключа вимкнено.",
+	INVALID_API_KEY: "недійсний API ключ.",
+	INVALID_USER_ID_FROM_API_KEY: "ID користувача з API ключа недійсний.",
+	INVALID_API_KEY_GETTER_RETURN_TYPE:
+		"отримувач API ключа повернув недійсний тип. Очікується: рядок.",
+	SERVER_ONLY_PROPERTY:
+		"властивість, яку ви намагаєтесь встановити, може бути встановлена лише з екземпляра автентифікації сервера.",
+	FAILED_TO_UPDATE_API_KEY: "не вдалося оновити API ключ",
+	NAME_REQUIRED: "ім'я API ключа обов'язкове.",
+} satisfies ApiKeyErrorCodesType;
+
+export const LOCALES = {
+	"uk-UA": UK_UA,
+} as const;

--- a/src/translations/plugins/device-authorization/uk.ts
+++ b/src/translations/plugins/device-authorization/uk.ts
@@ -1,0 +1,19 @@
+import type { DeviceAuthorizationErrorCodesType } from "../../../types";
+
+export const UK_UA = {
+	// Device authorization related errors
+	INVALID_DEVICE_CODE: "Невірний код пристрою",
+	EXPIRED_DEVICE_CODE: "Код пристрою прострочено",
+	EXPIRED_USER_CODE: "Код користувача прострочено",
+	AUTHORIZATION_PENDING: "Авторизація очікує",
+	ACCESS_DENIED: "Доступ заборонено",
+	INVALID_USER_CODE: "Невірний код користувача",
+	DEVICE_CODE_ALREADY_PROCESSED: "Код пристрою вже оброблено",
+	POLLING_TOO_FREQUENTLY: "Занадто часті запити",
+	INVALID_DEVICE_CODE_STATUS: "Невірний статус коду пристрою",
+	AUTHENTICATION_REQUIRED: "Потрібна автентифікація",
+} satisfies DeviceAuthorizationErrorCodesType;
+
+export const LOCALES = {
+	"uk-UA": UK_UA,
+} as const;

--- a/src/translations/plugins/email-otp/uk.ts
+++ b/src/translations/plugins/email-otp/uk.ts
@@ -1,0 +1,10 @@
+import type { EmailOTPErrorCodesType } from "../../../types";
+
+export const UK_UA = {
+	// Email OTP related errors
+	TOO_MANY_ATTEMPTS: "Забагато спроб",
+} satisfies EmailOTPErrorCodesType;
+
+export const LOCALES = {
+	"uk-UA": UK_UA,
+} as const;

--- a/src/translations/plugins/generic-oauth/uk.ts
+++ b/src/translations/plugins/generic-oauth/uk.ts
@@ -1,0 +1,10 @@
+import type { GenericOAuthErrorCodesType } from "../../../types";
+
+export const UK_UA = {
+	// Generic OAuth related errors
+	INVALID_OAUTH_CONFIGURATION: "Невірна конфігурація OAuth",
+} satisfies GenericOAuthErrorCodesType;
+
+export const LOCALES = {
+	"uk-UA": UK_UA,
+} as const;

--- a/src/translations/plugins/have-i-been-pwned/uk.ts
+++ b/src/translations/plugins/have-i-been-pwned/uk.ts
@@ -1,0 +1,11 @@
+import type { HaveIBeenPwnedErrorCodesType } from "../../../types";
+
+export const UK_UA = {
+	// Have I Been Pwned related errors
+	PASSWORD_COMPROMISED:
+		"Пароль, який ви ввели, було скомпрометовано. Будь ласка, виберіть інший пароль.",
+} satisfies HaveIBeenPwnedErrorCodesType;
+
+export const LOCALES = {
+	"uk-UA": UK_UA,
+} as const;

--- a/src/translations/plugins/multi-session/uk.ts
+++ b/src/translations/plugins/multi-session/uk.ts
@@ -1,0 +1,10 @@
+import type { MultiSessionErrorCodesType } from "../../../types";
+
+export const UK_UA = {
+	// Multi session related errors
+	INVALID_SESSION_TOKEN: "Невірний токен сесії",
+} satisfies MultiSessionErrorCodesType;
+
+export const LOCALES = {
+	"uk-UA": UK_UA,
+} as const;

--- a/src/translations/plugins/organization/uk.ts
+++ b/src/translations/plugins/organization/uk.ts
@@ -1,0 +1,81 @@
+import type { OrganizationErrorCodesType } from "../../../types";
+
+export const UK_UA = {
+	// Organization related errors
+	YOU_ARE_NOT_ALLOWED_TO_CREATE_A_NEW_ORGANIZATION:
+		"Ви не маєте дозволу на створення нової організації",
+	YOU_HAVE_REACHED_THE_MAXIMUM_NUMBER_OF_ORGANIZATIONS:
+		"Ви досягли максимальної кількості організацій",
+	ORGANIZATION_ALREADY_EXISTS: "Організація вже існує",
+	ORGANIZATION_NOT_FOUND: "Організацію не знайдено",
+	USER_IS_NOT_A_MEMBER_OF_THE_ORGANIZATION:
+		"Користувач не є членом організації",
+	YOU_ARE_NOT_ALLOWED_TO_UPDATE_THIS_ORGANIZATION:
+		"Ви не маєте дозволу на оновлення цієї організації",
+	YOU_ARE_NOT_ALLOWED_TO_DELETE_THIS_ORGANIZATION:
+		"Ви не маєте дозволу на видалення цієї організації",
+	NO_ACTIVE_ORGANIZATION: "Немає активної організації",
+	USER_IS_ALREADY_A_MEMBER_OF_THIS_ORGANIZATION:
+		"Користувач вже є членом цієї організації",
+	MEMBER_NOT_FOUND: "Члена не знайдено",
+	ROLE_NOT_FOUND: "Роль не знайдено",
+	YOU_ARE_NOT_ALLOWED_TO_CREATE_A_NEW_TEAM:
+		"Ви не маєте дозволу на створення нової команди",
+	TEAM_ALREADY_EXISTS: "Команда вже існує",
+	TEAM_NOT_FOUND: "Команду не знайдено",
+	YOU_CANNOT_LEAVE_THE_ORGANIZATION_AS_THE_ONLY_OWNER:
+		"Ви не можете залишити організацію як єдиний власник",
+	YOU_CANNOT_LEAVE_THE_ORGANIZATION_WITHOUT_AN_OWNER:
+		"Ви не можете залишити організацію без власника",
+	YOU_ARE_NOT_ALLOWED_TO_DELETE_THIS_MEMBER:
+		"Ви не маєте дозволу на видалення цього члена",
+	YOU_ARE_NOT_ALLOWED_TO_INVITE_USERS_TO_THIS_ORGANIZATION:
+		"Ви не маєте дозволу на запрошення користувачів до цієї організації",
+	USER_IS_ALREADY_INVITED_TO_THIS_ORGANIZATION:
+		"Користувача вже запрошено до цієї організації",
+	INVITATION_NOT_FOUND: "Запрошення не знайдено",
+	YOU_ARE_NOT_THE_RECIPIENT_OF_THE_INVITATION:
+		"Ви не є отримувачем запрошення",
+	EMAIL_VERIFICATION_REQUIRED_BEFORE_ACCEPTING_OR_REJECTING_INVITATION:
+		"Потрібна перевірка електронної пошти перед прийняттям або відхиленням запрошення",
+	YOU_ARE_NOT_ALLOWED_TO_CANCEL_THIS_INVITATION:
+		"Ви не маєте дозволу на скасування цього запрошення",
+	INVITER_IS_NO_LONGER_A_MEMBER_OF_THE_ORGANIZATION:
+		"Запрошуючий більше не є членом організації",
+	YOU_ARE_NOT_ALLOWED_TO_INVITE_USER_WITH_THIS_ROLE:
+		"Ви не маєте дозволу на запрошення користувача з цією роллю",
+	FAILED_TO_RETRIEVE_INVITATION: "Не вдалося отримати запрошення",
+	YOU_HAVE_REACHED_THE_MAXIMUM_NUMBER_OF_TEAMS:
+		"Ви досягли максимальної кількості команд",
+	UNABLE_TO_REMOVE_LAST_TEAM: "Неможливо видалити останню команду",
+	YOU_ARE_NOT_ALLOWED_TO_UPDATE_THIS_MEMBER:
+		"Ви не маєте дозволу на оновлення цього члена",
+	ORGANIZATION_MEMBERSHIP_LIMIT_REACHED:
+		"Досягнуто ліміт членства в організації",
+	YOU_ARE_NOT_ALLOWED_TO_CREATE_TEAMS_IN_THIS_ORGANIZATION:
+		"Ви не маєте дозволу на створення команд у цій організації",
+	YOU_ARE_NOT_ALLOWED_TO_DELETE_TEAMS_IN_THIS_ORGANIZATION:
+		"Ви не маєте дозволу на видалення команд у цій організації",
+	YOU_ARE_NOT_ALLOWED_TO_UPDATE_THIS_TEAM:
+		"Ви не маєте дозволу на оновлення цієї команди",
+	YOU_ARE_NOT_ALLOWED_TO_DELETE_THIS_TEAM:
+		"Ви не маєте дозволу на видалення цієї команди",
+	INVITATION_LIMIT_REACHED: "Досягнуто ліміт запрошень",
+	TEAM_MEMBER_LIMIT_REACHED: "Досягнуто ліміт членів команди",
+	USER_IS_NOT_A_MEMBER_OF_THE_TEAM: "Користувач не є членом команди",
+	YOU_CAN_NOT_ACCESS_THE_MEMBERS_OF_THIS_TEAM:
+		"Ви не маєте дозволу на доступ до членів цієї команди",
+	YOU_DO_NOT_HAVE_AN_ACTIVE_TEAM: "У вас немає активної команди",
+	YOU_ARE_NOT_ALLOWED_TO_CREATE_A_NEW_TEAM_MEMBER:
+		"Ви не маєте дозволу на створення нового члена команди",
+	YOU_ARE_NOT_ALLOWED_TO_REMOVE_A_TEAM_MEMBER:
+		"Ви не маєте дозволу на видалення члена команди",
+	YOU_ARE_NOT_ALLOWED_TO_ACCESS_THIS_ORGANIZATION:
+		"Ви не маєте дозволу на доступ до цієї організації як власник",
+	YOU_ARE_NOT_A_MEMBER_OF_THIS_ORGANIZATION:
+		"Ви не є членом цієї організації",
+} satisfies OrganizationErrorCodesType;
+
+export const LOCALES = {
+	"uk-UA": UK_UA,
+} as const;

--- a/src/translations/plugins/passkey/uk.ts
+++ b/src/translations/plugins/passkey/uk.ts
@@ -1,0 +1,17 @@
+import type { PasskeyErrorCodesType } from "../../../types";
+
+export const UK_UA = {
+	// Passkey related errors
+	CHALLENGE_NOT_FOUND: "Виклик не знайдено",
+	YOU_ARE_NOT_ALLOWED_TO_REGISTER_THIS_PASSKEY:
+		"Ви не маєте дозволу на реєстрацію цього ключа доступу",
+	FAILED_TO_VERIFY_REGISTRATION: "Не вдалося перевірити реєстрацію",
+	PASSKEY_NOT_FOUND: "Ключ доступу не знайдено",
+	AUTHENTICATION_FAILED: "Помилка автентифікації",
+	UNABLE_TO_CREATE_SESSION: "Не вдалося створити сесію",
+	FAILED_TO_UPDATE_PASSKEY: "Не вдалося оновити ключ доступу",
+} satisfies PasskeyErrorCodesType;
+
+export const LOCALES = {
+	"uk-UA": UK_UA,
+} as const;

--- a/src/translations/plugins/phone-number/uk.ts
+++ b/src/translations/plugins/phone-number/uk.ts
@@ -1,0 +1,17 @@
+import type { PhoneNumberErrorCodesType } from "../../../types";
+
+export const UK_UA = {
+	// Phone number related errors
+	INVALID_PHONE_NUMBER: "Невірний номер телефону",
+	PHONE_NUMBER_EXIST: "Номер телефону вже існує",
+	INVALID_PHONE_NUMBER_OR_PASSWORD: "Невірний номер телефону або пароль",
+	UNEXPECTED_ERROR: "Неочікувана помилка",
+	OTP_NOT_FOUND: "Код підтвердження не знайдено",
+	OTP_EXPIRED: "Код підтвердження прострочено",
+	INVALID_OTP: "Невірний код підтвердження",
+	PHONE_NUMBER_NOT_VERIFIED: "Номер телефону не підтверджено",
+} satisfies PhoneNumberErrorCodesType;
+
+export const LOCALES = {
+	"uk-UA": UK_UA,
+} as const;

--- a/src/translations/plugins/two-factor/uk.ts
+++ b/src/translations/plugins/two-factor/uk.ts
@@ -1,0 +1,19 @@
+import type { TwoFactorErrorCodesType } from "../../../types";
+
+export const UK_UA = {
+	// Two Factor related errors
+	OTP_NOT_ENABLED: "Одноразовий пароль не увімкнено",
+	OTP_HAS_EXPIRED: "Одноразовий пароль прострочено",
+	TOTP_NOT_ENABLED: "Тимчасовий одноразовий пароль не увімкнено",
+	TWO_FACTOR_NOT_ENABLED: "Двофакторну автентифікацію не увімкнено",
+	BACKUP_CODES_NOT_ENABLED: "Резервні коди не увімкнено",
+	INVALID_BACKUP_CODE: "Невірний резервний код",
+	INVALID_CODE: "Невірний код",
+	TOO_MANY_ATTEMPTS_REQUEST_NEW_CODE:
+		"Забагато спроб. Запросіть новий код.",
+	INVALID_TWO_FACTOR_COOKIE: "Невірний cookie двофакторної автентифікації",
+} satisfies TwoFactorErrorCodesType;
+
+export const LOCALES = {
+	"uk-UA": UK_UA,
+} as const;

--- a/src/translations/plugins/username/uk.ts
+++ b/src/translations/plugins/username/uk.ts
@@ -1,0 +1,15 @@
+import type { UsernameErrorCodesType } from "../../../types";
+
+export const UK_UA = {
+	// Username related errors
+	INVALID_USERNAME_OR_PASSWORD: "Невірне ім'я користувача або пароль",
+	USERNAME_IS_ALREADY_TAKEN: "Ім'я користувача вже зайнято. Спробуйте інше.",
+	USERNAME_TOO_SHORT: "Ім'я користувача занадто коротке",
+	USERNAME_TOO_LONG: "Ім'я користувача занадто довге",
+	INVALID_USERNAME: "Невірне ім'я користувача",
+	INVALID_DISPLAY_USERNAME: "Невірне відображуване ім'я",
+} satisfies UsernameErrorCodesType;
+
+export const LOCALES = {
+	"uk-UA": UK_UA,
+} as const;

--- a/src/translations/uk.ts
+++ b/src/translations/uk.ts
@@ -1,0 +1,47 @@
+import { createTranslationObject } from "../utils/create-translation-object";
+
+export const UK_UA = createTranslationObject("uk-UA", {
+	// User related errors
+	USER_NOT_FOUND: "Користувача не знайдено",
+	FAILED_TO_CREATE_USER: "Не вдалося створити користувача",
+	FAILED_TO_UPDATE_USER: "Не вдалося оновити користувача",
+	USER_ALREADY_EXISTS: "Користувач вже існує",
+	USER_EMAIL_NOT_FOUND: "Email користувача не знайдено",
+	USER_ALREADY_HAS_PASSWORD:
+		"Користувач вже має пароль. Вкажіть цей пароль для видалення акаунта.",
+	USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL:
+		"Користувач вже існує. Використайте інший email.",
+
+	// Session related errors
+	FAILED_TO_CREATE_SESSION: "Не вдалося створити сесію",
+	FAILED_TO_GET_SESSION: "Не вдалося отримати сесію",
+	SESSION_EXPIRED:
+		"Сесія закінчилася. Увійдіть знову для виконання цієї дії.",
+
+	// Authentication errors
+	INVALID_PASSWORD: "Невірний пароль",
+	INVALID_EMAIL: "Невірний email",
+	INVALID_EMAIL_OR_PASSWORD: "Невірний email або пароль",
+	INVALID_TOKEN: "Невірний токен",
+	EMAIL_NOT_VERIFIED: "Email не підтверджено",
+	CREDENTIAL_ACCOUNT_NOT_FOUND: "Обліковий запис не знайдено",
+
+	// Password related errors
+	PASSWORD_TOO_SHORT: "Пароль занадто короткий",
+	PASSWORD_TOO_LONG: "Пароль занадто довгий",
+
+	// Social auth errors
+	SOCIAL_ACCOUNT_ALREADY_LINKED: "Акаунт вже прив'язано",
+	PROVIDER_NOT_FOUND: "Провайдера не знайдено",
+	ID_TOKEN_NOT_SUPPORTED: "id_token не підтримується",
+	FAILED_TO_GET_USER_INFO: "Не вдалося отримати інформацію про користувача",
+
+	// Account management errors
+	EMAIL_CAN_NOT_BE_UPDATED: "Email не можна оновити",
+	FAILED_TO_UNLINK_LAST_ACCOUNT: "Неможливо відв'язати останній акаунт",
+	ACCOUNT_NOT_FOUND: "Акаунт не знайдено",
+});
+
+export const LOCALES = {
+	"uk-UA": UK_UA,
+} as const;


### PR DESCRIPTION
## Summary
- Add complete Ukrainian (uk-UA) translations for Better Auth localization plugin
- Core library: user, session, authentication, password, social auth, account management errors
- All 13 official plugins: admin, anonymous, api-key, device-authorization, email-otp, generic-oauth, have-i-been-pwned, multi-session, organization, passkey, phone-number, two-factor, username

## Test plan
- [x] TypeScript type check passes (`npm run tsc`)
- [x] Translation index generated successfully (`npm run generate:translations`)
