### PR TITLE
Migrate to better-auth v1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,13 +63,13 @@
 		"@biomejs/biome": "^2.1.3",
 		"@changesets/cli": "^2.29.5",
 		"@types/node": "^24.1.0",
-		"better-auth": "^1.3.27",
+		"better-auth": "^1.5.0",
 		"prompts": "^2.4.2",
 		"tsup": "^8.5.0",
 		"typescript": "^5.8.3",
 		"vitest": "^3.2.4"
 	},
 	"peerDependencies": {
-		"better-auth": "^1.4.19"
+		"better-auth": "^1.5.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,16 @@
 		"vitest": "^3.2.4"
 	},
 	"peerDependencies": {
-		"better-auth": "^1.5.0"
+		"better-auth": "^1.5.0",
+		"@better-auth/api-key": "^1.5.0",
+		"@better-auth/passkey": "^1.5.0"
+	},
+	"peerDependenciesMeta": {
+		"@better-auth/api-key": {
+			"optional": true
+		},
+		"@better-auth/passkey": {
+			"optional": true
+		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,87 +1,87 @@
 {
-  "name": "better-auth-localization",
-  "version": "2.3.1",
-  "author": "Marcel Losso",
-  "description": " A custom plugin for better-auth that allows you to localize your error messages.",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist",
-    "LICENSE.md",
-    "README.md"
-  ],
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
-    }
-  },
-  "scripts": {
-    "generate:translations": "node scripts/generate-translations-index.cjs",
-    "generate:locale": "node scripts/create-locale.cjs",
-    "postgenerate:locale": "pnpm generate:translations",
-    "prebuild": "pnpm generate:translations",
-    "build": "tsup",
-    "predev": "pnpm generate:translations",
-    "dev": "tsup --watch",
-    "pretest": "pnpm generate:translations",
-    "test": "vitest",
-    "pretest:ci": "pnpm generate:translations",
-    "test:ci": "vitest run",
-    "lint": "biome check .",
-    "lint:fix": "biome check --write .",
-    "format": "biome format --write .",
-    "pretsc": "pnpm generate:translations",
-    "tsc": "tsc --noEmit",
-    "prerelease": "pnpm build",
-    "release": "changeset publish"
-  },
-  "keywords": [
-    "better-auth",
-    "better-localization",
-    "better-auth-localization",
-    "localization",
-    "i18n",
-    "internationalization",
-    "translation",
-    "language",
-    "locale"
-  ],
-  "license": "MIT",
-  "homepage": "https://github.com/marcellosso/better-auth-localization",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/marcellosso/better-auth-localization.git"
-  },
-  "bugs": {
-    "url": "https://github.com/marcellosso/better-auth-localization/issues"
-  },
-  "packageManager": "pnpm@10.13.1",
-  "devDependencies": {
-    "@better-auth/api-key": "^1.5.0",
-    "@better-auth/passkey": "^1.5.0",
-    "@biomejs/biome": "^2.1.3",
-    "@changesets/cli": "^2.29.5",
-    "@types/node": "^24.1.0",
-    "better-auth": "^1.5.0",
-    "prompts": "^2.4.2",
-    "tsup": "^8.5.0",
-    "typescript": "^5.8.3",
-    "vitest": "^3.2.4"
-  },
-  "peerDependencies": {
-    "better-auth": "^1.5.0",
-    "@better-auth/api-key": "^1.5.0",
-    "@better-auth/passkey": "^1.5.0"
-  },
-  "peerDependenciesMeta": {
-    "@better-auth/api-key": {
-      "optional": true
-    },
-    "@better-auth/passkey": {
-      "optional": true
-    }
-  }
+	"name": "better-auth-localization",
+	"version": "2.3.1",
+	"author": "Marcel Losso",
+	"description": " A custom plugin for better-auth that allows you to localize your error messages.",
+	"main": "dist/index.js",
+	"module": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"files": [
+		"dist",
+		"LICENSE.md",
+		"README.md"
+	],
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.mjs",
+			"require": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"generate:translations": "node scripts/generate-translations-index.cjs",
+		"generate:locale": "node scripts/create-locale.cjs",
+		"postgenerate:locale": "pnpm generate:translations",
+		"prebuild": "pnpm generate:translations",
+		"build": "tsup",
+		"predev": "pnpm generate:translations",
+		"dev": "tsup --watch",
+		"pretest": "pnpm generate:translations",
+		"test": "vitest",
+		"pretest:ci": "pnpm generate:translations",
+		"test:ci": "vitest run",
+		"lint": "biome check .",
+		"lint:fix": "biome check --write .",
+		"format": "biome format --write .",
+		"pretsc": "pnpm generate:translations",
+		"tsc": "tsc --noEmit",
+		"prerelease": "pnpm build",
+		"release": "changeset publish"
+	},
+	"keywords": [
+		"better-auth",
+		"better-localization",
+		"better-auth-localization",
+		"localization",
+		"i18n",
+		"internationalization",
+		"translation",
+		"language",
+		"locale"
+	],
+	"license": "MIT",
+	"homepage": "https://github.com/marcellosso/better-auth-localization",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/marcellosso/better-auth-localization.git"
+	},
+	"bugs": {
+		"url": "https://github.com/marcellosso/better-auth-localization/issues"
+	},
+	"packageManager": "pnpm@10.13.1",
+	"devDependencies": {
+		"@better-auth/api-key": "^1.5.0",
+		"@better-auth/passkey": "^1.5.0",
+		"@biomejs/biome": "^2.1.3",
+		"@changesets/cli": "^2.29.5",
+		"@types/node": "^24.1.0",
+		"better-auth": "^1.5.0",
+		"prompts": "^2.4.2",
+		"tsup": "^8.5.0",
+		"typescript": "^5.8.3",
+		"vitest": "^3.2.4"
+	},
+	"peerDependencies": {
+		"better-auth": "^1.5.0",
+		"@better-auth/api-key": "^1.5.0",
+		"@better-auth/passkey": "^1.5.0"
+	},
+	"peerDependenciesMeta": {
+		"@better-auth/api-key": {
+			"optional": true
+		},
+		"@better-auth/passkey": {
+			"optional": true
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,85 +1,87 @@
 {
-	"name": "better-auth-localization",
-	"version": "2.3.1",
-	"author": "Marcel Losso",
-	"description": " A custom plugin for better-auth that allows you to localize your error messages.",
-	"main": "dist/index.js",
-	"module": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"files": [
-		"dist",
-		"LICENSE.md",
-		"README.md"
-	],
-	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.mjs",
-			"require": "./dist/index.js"
-		}
-	},
-	"scripts": {
-		"generate:translations": "node scripts/generate-translations-index.cjs",
-		"generate:locale": "node scripts/create-locale.cjs",
-		"postgenerate:locale": "pnpm generate:translations",
-		"prebuild": "pnpm generate:translations",
-		"build": "tsup",
-		"predev": "pnpm generate:translations",
-		"dev": "tsup --watch",
-		"pretest": "pnpm generate:translations",
-		"test": "vitest",
-		"pretest:ci": "pnpm generate:translations",
-		"test:ci": "vitest run",
-		"lint": "biome check .",
-		"lint:fix": "biome check --write .",
-		"format": "biome format --write .",
-		"pretsc": "pnpm generate:translations",
-		"tsc": "tsc --noEmit",
-		"prerelease": "pnpm build",
-		"release": "changeset publish"
-	},
-	"keywords": [
-		"better-auth",
-		"better-localization",
-		"better-auth-localization",
-		"localization",
-		"i18n",
-		"internationalization",
-		"translation",
-		"language",
-		"locale"
-	],
-	"license": "MIT",
-	"homepage": "https://github.com/marcellosso/better-auth-localization",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/marcellosso/better-auth-localization.git"
-	},
-	"bugs": {
-		"url": "https://github.com/marcellosso/better-auth-localization/issues"
-	},
-	"packageManager": "pnpm@10.13.1",
-	"devDependencies": {
-		"@biomejs/biome": "^2.1.3",
-		"@changesets/cli": "^2.29.5",
-		"@types/node": "^24.1.0",
-		"better-auth": "^1.5.0",
-		"prompts": "^2.4.2",
-		"tsup": "^8.5.0",
-		"typescript": "^5.8.3",
-		"vitest": "^3.2.4"
-	},
-	"peerDependencies": {
-		"better-auth": "^1.5.0",
-		"@better-auth/api-key": "^1.5.0",
-		"@better-auth/passkey": "^1.5.0"
-	},
-	"peerDependenciesMeta": {
-		"@better-auth/api-key": {
-			"optional": true
-		},
-		"@better-auth/passkey": {
-			"optional": true
-		}
-	}
+  "name": "better-auth-localization",
+  "version": "2.3.1",
+  "author": "Marcel Losso",
+  "description": " A custom plugin for better-auth that allows you to localize your error messages.",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "LICENSE.md",
+    "README.md"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "generate:translations": "node scripts/generate-translations-index.cjs",
+    "generate:locale": "node scripts/create-locale.cjs",
+    "postgenerate:locale": "pnpm generate:translations",
+    "prebuild": "pnpm generate:translations",
+    "build": "tsup",
+    "predev": "pnpm generate:translations",
+    "dev": "tsup --watch",
+    "pretest": "pnpm generate:translations",
+    "test": "vitest",
+    "pretest:ci": "pnpm generate:translations",
+    "test:ci": "vitest run",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "format": "biome format --write .",
+    "pretsc": "pnpm generate:translations",
+    "tsc": "tsc --noEmit",
+    "prerelease": "pnpm build",
+    "release": "changeset publish"
+  },
+  "keywords": [
+    "better-auth",
+    "better-localization",
+    "better-auth-localization",
+    "localization",
+    "i18n",
+    "internationalization",
+    "translation",
+    "language",
+    "locale"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/marcellosso/better-auth-localization",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/marcellosso/better-auth-localization.git"
+  },
+  "bugs": {
+    "url": "https://github.com/marcellosso/better-auth-localization/issues"
+  },
+  "packageManager": "pnpm@10.13.1",
+  "devDependencies": {
+    "@better-auth/api-key": "^1.5.0",
+    "@better-auth/passkey": "^1.5.0",
+    "@biomejs/biome": "^2.1.3",
+    "@changesets/cli": "^2.29.5",
+    "@types/node": "^24.1.0",
+    "better-auth": "^1.5.0",
+    "prompts": "^2.4.2",
+    "tsup": "^8.5.0",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4"
+  },
+  "peerDependencies": {
+    "better-auth": "^1.5.0",
+    "@better-auth/api-key": "^1.5.0",
+    "@better-auth/passkey": "^1.5.0"
+  },
+  "peerDependenciesMeta": {
+    "@better-auth/api-key": {
+      "optional": true
+    },
+    "@better-auth/passkey": {
+      "optional": true
+    }
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthPlugin, Status } from "better-auth";
-import { createAuthMiddleware } from "better-auth/plugins";
+import { createAuthMiddleware } from "better-auth/api";
 import { defaultTranslations } from "./translations";
 import type {
 	AvailableLocales,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,20 +3,19 @@ import type {
 	AdminOptions,
 	admin,
 	anonymous,
-	apiKey,
 	deviceAuthorization,
 	emailOTP,
 	genericOAuth,
 	haveIBeenPwned,
 	multiSession,
-	OrganizationOptions,
-	organization,
 	phoneNumber,
 	TWO_FACTOR_ERROR_CODES,
 	USERNAME_ERROR_CODES,
 	captcha,
 } from "better-auth/plugins";
-import type { passkey } from "better-auth/plugins/passkey";
+import type { ORGANIZATION_ERROR_CODES } from "better-auth/client/plugins";
+import type { apiKey } from "@better-auth/api-key";
+import type { passkey } from "@better-auth/passkey";
 import type { defaultTranslations } from "../translations";
 
 type Prettify<T> = {
@@ -37,7 +36,7 @@ type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
 export type AuthErrorCodesType = RemoveReadonly<Auth["$ERROR_CODES"]>;
 
 export type OrganizationErrorCodesType = RemoveReadonly<
-	ReturnType<typeof organization<OrganizationOptions>>["$ERROR_CODES"]
+	typeof ORGANIZATION_ERROR_CODES
 >;
 
 export type TwoFactorErrorCodesType = RemoveReadonly<


### PR DESCRIPTION
## Summary

Migrates the package to be fully compatible with better-auth v1.5.0. Updates broken import paths, fixes type incompatibilities introduced by upstream API changes, restructures dependency declarations to reflect plugin package extractions, and applies code formatting fixes.

## What changed

### Import path fixes

- **`src/index.ts`**: Changed `import { createAuthMiddleware } from "better-auth/plugins"` to `import { createAuthMiddleware } from "better-auth/api"` — v1.5 moved middleware to a unified hooks system under `better-auth/api`

### Type fixes

- **`src/types/index.ts`**: Fixed `OrganizationErrorCodesType` — the `organization()` plugin now has mutually exclusive generic overloads for `teams`/`dynamicAccessControl`, making it impossible to use `ReturnType<typeof organization<OrganizationOptions>>`. Replaced with `typeof ORGANIZATION_ERROR_CODES` imported directly from `better-auth/client/plugins` (same pattern already used for `TWO_FACTOR_ERROR_CODES` and `USERNAME_ERROR_CODES`)
- **`src/types/index.ts`**: Removed unused `OrganizationOptions` and `organization` imports

### Dependency restructuring

- **`package.json`**: Bumped `better-auth` to `^1.5.0` (dev + peer)
- **`package.json`**: Added `@better-auth/api-key` and `@better-auth/passkey` to optional `peerDependencies` with `peerDependenciesMeta` — these are only used for `import type` so there's no runtime dependency; users who use those plugins already have them installed
- **`package.json`**: Added `@better-auth/api-key` and `@better-auth/passkey` to `devDependencies` for local build/type-checking

## Why

better-auth v1.5.0 introduced several breaking changes relevant to this package:

1. **Unified hooks** — `createAuthMiddleware` moved from `better-auth/plugins` to `better-auth/api`
2. **Plugin extractions** — `@better-auth/api-key` and `@better-auth/passkey` are now separate packages (no longer re-exported from `better-auth/plugins`)
3. **`$ERROR_CODES` type changed to `RawError` objects** — plugin error codes now use `defineErrorCodes()` returning `{ code, message }` objects instead of plain strings
4. **Organization plugin overloads** — the `organization()` generic now has mutually exclusive type constraints for `teams` and `dynamicAccessControl` options

All tests pass. No runtime behavior changes.

### Reference: [v1.5.0 release notes](https://github.com/better-auth/better-auth/releases/tag/v1.5.0)
